### PR TITLE
🔧 chore: update revel-commit to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     }
   },
   "devDependencies": {
-    "revel-commit": "^1.1.2"
+    "revel-commit": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,10 +1523,10 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-revel-commit@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/revel-commit/-/revel-commit-1.1.2.tgz#1804ecebfed2bf3dcf4130560ac189666e1bd5ca"
-  integrity sha512-jKtC3sdohQzoe5HWjrPMVm7ShQ9YLloi1AgfSq9RhJ0ZW9cvCL12ddaLO+BkoP4djrgSYcxXUy58NJrNbQkv6Q==
+revel-commit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/revel-commit/-/revel-commit-1.2.0.tgz#d20ff6f9aadca5d3389d19864bb38fd171567d58"
+  integrity sha512-JEL2jpK6ALutj2g8woxosAuiEHIBlMxYwXOWfMLAPv1+Kv7ZB1Jk4DXmIa0uvqoGMWWNcaHjAsGyOYj0vj+gRQ==
   dependencies:
     "@dionlarson/commitizen" "^0.0.0-semantically-released"
     cz-conventional-changelog-for-shortcut "^7.2.2"


### PR DESCRIPTION
PR opened via `meta exec "gh pr create --fill -r alengel -r devisalona -r eywolfe -r cgm42 -r stel-dare"` 🤯 